### PR TITLE
Fix typo

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -377,8 +377,7 @@ else
   # - https://github.com/catkin/catkin_tools/issues/405
   # - https://github.com/ros-planning/moveit_ci/pull/18
   #travis_wait 60 catkin run_tests -i --no-deps --no-status $TEST_PKGS $CATKIN_PARALLEL_TEST_JOBS --make-args $ROS_PARALLEL_TEST_JOBS $CMAKE_ARGS_FLAGS --
-  travis_wait 60 catkin -i --no-deps --no-status $TEST_PKGS $CATKIN_PARALLEL_TEST_JOBS --make-args tests $ROS_PARALLEL_TEST_JOBS $CMAKE_ARGS_FLAGS --
-  travis_wait 60 catkin --catkin-make-args run_tests -i --no-deps --no-status $TEST_PKGS $CATKIN_PARALLEL_TEST_JOBS --make-args $ROS_PARALLEL_TEST_JOBS $CMAKE_ARGS_FLAGS --
+  travis_wait 60 catkin build --catkin-make-args run_tests -i --no-deps --no-status $TEST_PKGS $CATKIN_PARALLEL_TEST_JOBS --make-args $ROS_PARALLEL_TEST_JOBS $CMAKE_ARGS_FLAGS --
 fi
 catkin_test_results --verbose --all build || error
 

--- a/travis.sh
+++ b/travis.sh
@@ -377,7 +377,7 @@ else
   # - https://github.com/catkin/catkin_tools/issues/405
   # - https://github.com/ros-planning/moveit_ci/pull/18
   #travis_wait 60 catkin run_tests -i --no-deps --no-status $TEST_PKGS $CATKIN_PARALLEL_TEST_JOBS --make-args $ROS_PARALLEL_TEST_JOBS $CMAKE_ARGS_FLAGS --
-  travis_wait 60 catkin build --catkin-make-args run_tests -i --no-deps --no-status $TEST_PKGS $CATKIN_PARALLEL_TEST_JOBS --make-args $ROS_PARALLEL_TEST_JOBS $CMAKE_ARGS_FLAGS --
+  travis_wait 60 catkin build --catkin-make-args run_tests -- -i --no-deps --no-status $TEST_PKGS $CATKIN_PARALLEL_TEST_JOBS --make-args $ROS_PARALLEL_TEST_JOBS $CMAKE_ARGS_FLAGS --
 fi
 catkin_test_results --verbose --all build || error
 


### PR DESCRIPTION
I think two lines are duplicate and word `build` is lacked.
```
The command catkin -i --no-deps --no-status grasp_fusion instance_occlsegm jsk_2015_05_baxter_apc jsk_apc2015_common jsk_2016_01_baxter_apc jsk_apc2016_common jsk_arc2017_common jsk_arc2017_baxter selective_dualarm_stowing synthetic2d -p4 --make-args tests -j2 -- exited with 1.

usage: catkin [-h] [-a] [--test-colors] [--version]

              [--force-color | --no-color]

              [build | clean | config | create | env | init | list | locate | profile]

              ...

Error: Unknown verb 'grasp_fusion' provided.
```
(from https://api.travis-ci.org/v3/job/601211626/log.txt)